### PR TITLE
Problem: travis osx infra does not have docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ script: ./ci_build.sh
 matrix:
   exclude:
   - os: osx
-      env: BUILD_TYPE=check_zproto
+    env: BUILD_TYPE=check_zproto
   - os: osx
-      env: BUILD_TYPE=check_zproject
+    env: BUILD_TYPE=check_zproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,10 @@ env:
 
 # Build and check this project according to the BUILD_TYPE
 script: ./ci_build.sh
+
+matrix:
+  exclude:
+  - os: osx
+      env: BUILD_TYPE=check_zproto
+  - os: osx
+      env: BUILD_TYPE=check_zproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
 # Build and check this project according to the BUILD_TYPE
 script: ./ci_build.sh
 
+
+# osx environment does not have docker
 matrix:
   exclude:
   - os: osx


### PR DESCRIPTION
Solution: avoid check_zproject and check_zproto when osx
