### PR TITLE
Problem: zeb_handler cannot deal with multiple accepts values

### DIFF
--- a/api/zeb_handler.xml
+++ b/api/zeb_handler.xml
@@ -12,7 +12,7 @@
     <actor>
         To work with zeb_handler, use the CZMQ zactor API:
 
-        Create new zeb_handler instance, passing broker endpoint:
+        Create new zeb_handler instance, passing the broker endpoint:
 
             zactor_t *handler = zactor_new (zeb_handler, "inproc://broker");
 
@@ -35,8 +35,8 @@
              zsock_signal (handler, 0);
           }
 
-          Check if a last modified timestamp is current, MUST signal 0 if true
-          otherwise 1.
+        Check if a last modified timestamp is current, MUST signal 0 if true
+        otherwise 1.
 
           if (streq (command, "CHECK LAST MODIFIED")) {
              uint64_t last_modified;
@@ -60,9 +60,15 @@
     <method name = "add offer" singleton = "1">
         Add a new offer this handler will handle. Returns 0 if successful,
         otherwise -1.
+        The content type parameter is optional and is used to
+        filter requests upon their requested (GET) or provided (POST/PUT)
+        content's type. The content type parameter may be a regex. If the
+        request's content type does not match it is automatically rejected
+        with the error code 406 (Not acceptable).
         <argument name = "self" type = "zactor" />
         <argument name = "method" type = "integer" />
         <argument name = "uri" type = "string" />
+        <argument name = "content type" type = "string" />
         <return type = "integer" />
     </method>
 

--- a/doc/zeb_handler.doc
+++ b/doc/zeb_handler.doc
@@ -10,7 +10,7 @@ This is the class interface:
     #ifdef ZEBRA_BUILD_DRAFT_API
     //  To work with zeb_handler, use the CZMQ zactor API:                      
     //                                                                          
-    //  Create new zeb_handler instance, passing broker endpoint:               
+    //  Create new zeb_handler instance, passing the broker endpoint:           
     //                                                                          
     //      zactor_t *handler = zactor_new (zeb_handler, "inproc://broker");    
     //                                                                          
@@ -33,8 +33,8 @@ This is the class interface:
     //       zsock_signal (handler, 0);                                         
     //    }                                                                     
     //                                                                          
-    //    Check if a last modified timestamp is current, MUST signal 0 if true  
-    //    otherwise 1.                                                          
+    //  Check if a last modified timestamp is current, MUST signal 0 if true    
+    //  otherwise 1.                                                            
     //                                                                          
     //    if (streq (command, "CHECK LAST MODIFIED")) {                         
     //       uint64_t last_modified;                                            
@@ -59,8 +59,13 @@ This is the class interface:
     //  *** Draft method, for development use, may change without warning ***
     //  Add a new offer this handler will handle. Returns 0 if successful,
     //  otherwise -1.                                                     
+    //  The content type parameter is optional and is used to             
+    //  filter requests upon their requested (GET) or provided (POST/PUT) 
+    //  content's type. The content type parameter may be a regex. If the 
+    //  request's content type does not match it is automatically rejected
+    //  with the error code 406 (Not acceptable).                         
     ZEBRA_EXPORT int
-        zeb_handler_add_offer (zactor_t *self, int method, const char *uri);
+        zeb_handler_add_offer (zactor_t *self, int method, const char *uri, const char *content_type);
     
     //  *** Draft method, for development use, may change without warning ***
     //  Add a new accept type that this handler can deliver. May be a regular
@@ -95,24 +100,20 @@ This is the class self test code:
     zactor_t *handler = zactor_new (zeb_handler, (void *) "tcp://127.0.0.1:9999");
     assert (handler);
     
-    //  Set accepted document formats
-    rc = zeb_handler_add_accept (handler, "application/(xml|json)");
-    assert (rc == 0);
-    
     //  Offer a service
-    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy");
+    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy", "application/(xml|json)");
     assert (rc == 0);
-    rc = zeb_handler_add_offer (handler, XRAP_MSG_PUT, "/dummy");
+    rc = zeb_handler_add_offer (handler, XRAP_MSG_PUT, "/dummy", "application/(xml|json)");
     assert (rc == 0);
     
     //  Provide Rubbish Offering
-    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy");
+    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy", NULL);
     assert (rc == -1);
     
     //  ================================
     //  GET Tests
     
-    //  Send Request
+    //  1.1 Send Request
     xrap_msg_t *xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/xml");
@@ -120,14 +121,14 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Receive request and Echo response
+    //  1.2 Receive request and Echo response
     char *command;
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
     
-    //  Receive Response (is echo)
+    //  1.3 Receive Response (is echo)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
@@ -137,14 +138,40 @@ This is the class self test code:
     zuuid_t *sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request without ACCEPT
+    //  2.1 Send Request with default Firefox accept header
+    xmsg = xrap_msg_new (XRAP_MSG_GET);
+    xrap_msg_set_resource (xmsg, "%s", "/dummy");
+    xrap_msg_set_content_type (xmsg,
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+    msg = xrap_msg_encode (&xmsg);
+    rc = zeb_client_request (client, 0, &msg);
+    assert (rc == 0);
+    
+    //  2.2 Receive request and Echo response
+    zsock_recv (handler, "sm", &command, &msg);
+    assert (streq (command, "HANDLE REQUEST"));
+    zstr_free (&command);
+    zmsg_send (&msg, handler);
+    
+    //  2.3 Receive Response (is echo)
+    msg = zeb_client_recv (client);
+    xmsg = xrap_msg_decode (&msg);
+    assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
+    assert (streq (xrap_msg_resource (xmsg), "/dummy"));
+    assert (streq (xrap_msg_content_type (xmsg),
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"));
+    xrap_msg_destroy (&xmsg);
+    sender = zeb_client_sender (client);
+    zuuid_destroy (&sender);
+    
+    //  3.1 Send Request without ACCEPT
     xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     msg = xrap_msg_encode (&xmsg);
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Receive Request without ACCEPT
+    //  3.2 Receive Request without ACCEPT
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_ERROR);
@@ -153,7 +180,7 @@ This is the class self test code:
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request with conditionals (not changed)
+    //  4.1 Send Request with conditionals (not changed)
     xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -163,7 +190,7 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Check etag (match)
+    //  4.2 Check etag (match)
     char *etag;
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
@@ -172,14 +199,14 @@ This is the class self test code:
     zstr_free (&etag);
     zsock_signal (handler, 0);
     
-    //  Check last modified (not modified)
+    //  4.3 Check last modified (not modified)
     uint64_t last_modified;
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     zsock_signal (handler, 0);
     
-    //  Receive Request with conditionals
+    //  4.4 Receive Request with conditionals
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_GET_EMPTY);
@@ -187,7 +214,7 @@ This is the class self test code:
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request with conditionals (changed)
+    //  5.1 Send Request with conditionals (changed)
     xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -197,7 +224,7 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Check etag (none match)
+    //  5.2 Check etag (none match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -205,20 +232,20 @@ This is the class self test code:
     zstr_free (&etag);
     zsock_signal (handler, 1);
     
-    //  Check last modified (modified)
+    //  5.3 Check last modified (modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     assert (last_modified == 20);
     zsock_signal (handler, 1);
     
-    //  Receive request and Echo response
+    //  5.4 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
     
-    //  Receive response with conditionals
+    //  5.5 Receive response with conditionals
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
@@ -231,7 +258,7 @@ This is the class self test code:
     //  ================================
     //  PUT Tests
     
-    //  Send Request
+    //  1.1 Send Request
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/xml");
@@ -240,13 +267,13 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Receive request and Echo response
+    //  1.2 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
     
-    //  Receive response (is echo)
+    //  1.3 Receive response (is echo)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -257,7 +284,7 @@ This is the class self test code:
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request with conditionals (update, both)
+    //  2.1 Send Request with conditionals (update, both)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -267,7 +294,7 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Check etag (match)
+    //  2.2 Check etag (match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -275,19 +302,19 @@ This is the class self test code:
     zstr_free (&etag);
     zsock_signal (handler, 0);
     
-    //  Check last modified (not modified)
+    //  2.3 Check last modified (not modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     zsock_signal (handler, 0);
     
-    //  Receive request and Echo response
+    //  2.4 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
     
-    //  Receive response with conditionals (update, both)
+    //  2.5 Receive response with conditionals (update, both)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -297,7 +324,7 @@ This is the class self test code:
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request with conditionals (update, etag)
+    //  3.1 Send Request with conditionals (update, etag)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -306,7 +333,7 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Check etag (match)
+    //  3.2 Check etag (match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -314,13 +341,13 @@ This is the class self test code:
     zstr_free (&etag);
     zsock_signal (handler, 0);
     
-    //  Receive request and Echo response
+    //  3.3 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
     
-    //  Receive response with conditionals (update, etag)
+    //  3.4 Receive response with conditionals (update, etag)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -328,7 +355,7 @@ This is the class self test code:
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request with conditionals (update, last_modified)
+    //  4.1 Send Request with conditionals (update, last_modified)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -337,19 +364,19 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Check last modified (not modified)
+    //  4.2 Check last modified (not modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     zsock_signal (handler, 0);
     
-    //  Receive request and Echo response
+    //  4.3 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
     
-    //  Receive response with conditionals (update, last_modified)
+    //  4.4 Receive response with conditionals (update, last_modified)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -357,7 +384,7 @@ This is the class self test code:
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
     
-    //  Send Request with conditionals (no update)
+    //  5.1 Send Request with conditionals (no update)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -367,7 +394,7 @@ This is the class self test code:
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
     
-    //  Check etag (none match)
+    //  5.2 Check etag (none match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -375,14 +402,14 @@ This is the class self test code:
     zstr_free (&etag);
     zsock_signal (handler, 1);
     
-    //  Check last modified (modified)
+    //  5.3 Check last modified (modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     assert (last_modified == 20);
     zsock_signal (handler, 1);
     
-    //  Receive Request with conditionals (no update)
+    //  5.4 Receive Request with conditionals (no update)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_ERROR);
@@ -394,12 +421,13 @@ This is the class self test code:
     //  ================================
     //  Invalid Tests
     
-    //  Send Request
+    //  1.1 Send Request
     xmsg = xrap_msg_new (XRAP_MSG_GET_EMPTY);
     msg = xrap_msg_encode (&xmsg);
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == XRAP_TRAFFIC_NOT_FOUND);
     
+    //  Cleanup
     zeb_client_destroy (&client);
     zactor_destroy (&handler);
     

--- a/doc/zeb_handler.txt
+++ b/doc/zeb_handler.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 #ifdef ZEBRA_BUILD_DRAFT_API
 //  To work with zeb_handler, use the CZMQ zactor API:                      
 //                                                                          
-//  Create new zeb_handler instance, passing broker endpoint:               
+//  Create new zeb_handler instance, passing the broker endpoint:           
 //                                                                          
 //      zactor_t *handler = zactor_new (zeb_handler, "inproc://broker");    
 //                                                                          
@@ -35,8 +35,8 @@ SYNOPSIS
 //       zsock_signal (handler, 0);                                         
 //    }                                                                     
 //                                                                          
-//    Check if a last modified timestamp is current, MUST signal 0 if true  
-//    otherwise 1.                                                          
+//  Check if a last modified timestamp is current, MUST signal 0 if true    
+//  otherwise 1.                                                            
 //                                                                          
 //    if (streq (command, "CHECK LAST MODIFIED")) {                         
 //       uint64_t last_modified;                                            
@@ -61,8 +61,13 @@ ZEBRA_EXPORT void
 //  *** Draft method, for development use, may change without warning ***
 //  Add a new offer this handler will handle. Returns 0 if successful,
 //  otherwise -1.                                                     
+//  The content type parameter is optional and is used to             
+//  filter requests upon their requested (GET) or provided (POST/PUT) 
+//  content's type. The content type parameter may be a regex. If the 
+//  request's content type does not match it is automatically rejected
+//  with the error code 406 (Not acceptable).                         
 ZEBRA_EXPORT int
-    zeb_handler_add_offer (zactor_t *self, int method, const char *uri);
+    zeb_handler_add_offer (zactor_t *self, int method, const char *uri, const char *content_type);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Add a new accept type that this handler can deliver. May be a regular
@@ -107,24 +112,20 @@ assert (zeb_client_connected (client) == true);
 zactor_t *handler = zactor_new (zeb_handler, (void *) "tcp://127.0.0.1:9999");
 assert (handler);
 
-//  Set accepted document formats
-rc = zeb_handler_add_accept (handler, "application/(xml|json)");
-assert (rc == 0);
-
 //  Offer a service
-rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy");
+rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy", "application/(xml|json)");
 assert (rc == 0);
-rc = zeb_handler_add_offer (handler, XRAP_MSG_PUT, "/dummy");
+rc = zeb_handler_add_offer (handler, XRAP_MSG_PUT, "/dummy", "application/(xml|json)");
 assert (rc == 0);
 
 //  Provide Rubbish Offering
-rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy");
+rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy", NULL);
 assert (rc == -1);
 
 //  ================================
 //  GET Tests
 
-//  Send Request
+//  1.1 Send Request
 xrap_msg_t *xmsg = xrap_msg_new (XRAP_MSG_GET);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/xml");
@@ -132,14 +133,14 @@ zmsg_t *msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Receive request and Echo response
+//  1.2 Receive request and Echo response
 char *command;
 zsock_recv (handler, "sm", &command, &msg);
 assert (streq (command, "HANDLE REQUEST"));
 zstr_free (&command);
 zmsg_send (&msg, handler);
 
-//  Receive Response (is echo)
+//  1.3 Receive Response (is echo)
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
@@ -149,14 +150,40 @@ xrap_msg_destroy (&xmsg);
 zuuid_t *sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request without ACCEPT
+//  2.1 Send Request with default Firefox accept header
+xmsg = xrap_msg_new (XRAP_MSG_GET);
+xrap_msg_set_resource (xmsg, "%s", "/dummy");
+xrap_msg_set_content_type (xmsg,
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+msg = xrap_msg_encode (&xmsg);
+rc = zeb_client_request (client, 0, &msg);
+assert (rc == 0);
+
+//  2.2 Receive request and Echo response
+zsock_recv (handler, "sm", &command, &msg);
+assert (streq (command, "HANDLE REQUEST"));
+zstr_free (&command);
+zmsg_send (&msg, handler);
+
+//  2.3 Receive Response (is echo)
+msg = zeb_client_recv (client);
+xmsg = xrap_msg_decode (&msg);
+assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
+assert (streq (xrap_msg_resource (xmsg), "/dummy"));
+assert (streq (xrap_msg_content_type (xmsg),
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"));
+xrap_msg_destroy (&xmsg);
+sender = zeb_client_sender (client);
+zuuid_destroy (&sender);
+
+//  3.1 Send Request without ACCEPT
 xmsg = xrap_msg_new (XRAP_MSG_GET);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Receive Request without ACCEPT
+//  3.2 Receive Request without ACCEPT
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_ERROR);
@@ -165,7 +192,7 @@ xrap_msg_destroy (&xmsg);
 sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request with conditionals (not changed)
+//  4.1 Send Request with conditionals (not changed)
 xmsg = xrap_msg_new (XRAP_MSG_GET);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/json");
@@ -175,7 +202,7 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Check etag (match)
+//  4.2 Check etag (match)
 char *etag;
 zsock_recv (handler, "ss", &command, &etag);
 assert (streq (command, "CHECK ETAG"));
@@ -184,14 +211,14 @@ assert (streq (etag, "MATCH"));
 zstr_free (&etag);
 zsock_signal (handler, 0);
 
-//  Check last modified (not modified)
+//  4.3 Check last modified (not modified)
 uint64_t last_modified;
 zsock_recv (handler, "s8", &command, &last_modified);
 assert (streq (command, "CHECK LAST MODIFIED"));
 zstr_free (&command);
 zsock_signal (handler, 0);
 
-//  Receive Request with conditionals
+//  4.4 Receive Request with conditionals
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_GET_EMPTY);
@@ -199,7 +226,7 @@ xrap_msg_destroy (&xmsg);
 sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request with conditionals (changed)
+//  5.1 Send Request with conditionals (changed)
 xmsg = xrap_msg_new (XRAP_MSG_GET);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/json");
@@ -209,7 +236,7 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Check etag (none match)
+//  5.2 Check etag (none match)
 zsock_recv (handler, "ss", &command, &etag);
 assert (streq (command, "CHECK ETAG"));
 zstr_free (&command);
@@ -217,20 +244,20 @@ assert (streq (etag, "NONE MATCH"));
 zstr_free (&etag);
 zsock_signal (handler, 1);
 
-//  Check last modified (modified)
+//  5.3 Check last modified (modified)
 zsock_recv (handler, "s8", &command, &last_modified);
 assert (streq (command, "CHECK LAST MODIFIED"));
 zstr_free (&command);
 assert (last_modified == 20);
 zsock_signal (handler, 1);
 
-//  Receive request and Echo response
+//  5.4 Receive request and Echo response
 zsock_recv (handler, "sm", &command, &msg);
 assert (streq (command, "HANDLE REQUEST"));
 zstr_free (&command);
 zmsg_send (&msg, handler);
 
-//  Receive response with conditionals
+//  5.5 Receive response with conditionals
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
@@ -243,7 +270,7 @@ zuuid_destroy (&sender);
 //  ================================
 //  PUT Tests
 
-//  Send Request
+//  1.1 Send Request
 xmsg = xrap_msg_new (XRAP_MSG_PUT);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/xml");
@@ -252,13 +279,13 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Receive request and Echo response
+//  1.2 Receive request and Echo response
 zsock_recv (handler, "sm", &command, &msg);
 assert (streq (command, "HANDLE REQUEST"));
 zstr_free (&command);
 zmsg_send (&msg, handler);
 
-//  Receive response (is echo)
+//  1.3 Receive response (is echo)
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -269,7 +296,7 @@ xrap_msg_destroy (&xmsg);
 sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request with conditionals (update, both)
+//  2.1 Send Request with conditionals (update, both)
 xmsg = xrap_msg_new (XRAP_MSG_PUT);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/json");
@@ -279,7 +306,7 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Check etag (match)
+//  2.2 Check etag (match)
 zsock_recv (handler, "ss", &command, &etag);
 assert (streq (command, "CHECK ETAG"));
 zstr_free (&command);
@@ -287,19 +314,19 @@ assert (streq (etag, "MATCH"));
 zstr_free (&etag);
 zsock_signal (handler, 0);
 
-//  Check last modified (not modified)
+//  2.3 Check last modified (not modified)
 zsock_recv (handler, "s8", &command, &last_modified);
 assert (streq (command, "CHECK LAST MODIFIED"));
 zstr_free (&command);
 zsock_signal (handler, 0);
 
-//  Receive request and Echo response
+//  2.4 Receive request and Echo response
 zsock_recv (handler, "sm", &command, &msg);
 assert (streq (command, "HANDLE REQUEST"));
 zstr_free (&command);
 zmsg_send (&msg, handler);
 
-//  Receive response with conditionals (update, both)
+//  2.5 Receive response with conditionals (update, both)
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -309,7 +336,7 @@ xrap_msg_destroy (&xmsg);
 sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request with conditionals (update, etag)
+//  3.1 Send Request with conditionals (update, etag)
 xmsg = xrap_msg_new (XRAP_MSG_PUT);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/json");
@@ -318,7 +345,7 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Check etag (match)
+//  3.2 Check etag (match)
 zsock_recv (handler, "ss", &command, &etag);
 assert (streq (command, "CHECK ETAG"));
 zstr_free (&command);
@@ -326,13 +353,13 @@ assert (streq (etag, "MATCH"));
 zstr_free (&etag);
 zsock_signal (handler, 0);
 
-//  Receive request and Echo response
+//  3.3 Receive request and Echo response
 zsock_recv (handler, "sm", &command, &msg);
 assert (streq (command, "HANDLE REQUEST"));
 zstr_free (&command);
 zmsg_send (&msg, handler);
 
-//  Receive response with conditionals (update, etag)
+//  3.4 Receive response with conditionals (update, etag)
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -340,7 +367,7 @@ xrap_msg_destroy (&xmsg);
 sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request with conditionals (update, last_modified)
+//  4.1 Send Request with conditionals (update, last_modified)
 xmsg = xrap_msg_new (XRAP_MSG_PUT);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/json");
@@ -349,19 +376,19 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Check last modified (not modified)
+//  4.2 Check last modified (not modified)
 zsock_recv (handler, "s8", &command, &last_modified);
 assert (streq (command, "CHECK LAST MODIFIED"));
 zstr_free (&command);
 zsock_signal (handler, 0);
 
-//  Receive request and Echo response
+//  4.3 Receive request and Echo response
 zsock_recv (handler, "sm", &command, &msg);
 assert (streq (command, "HANDLE REQUEST"));
 zstr_free (&command);
 zmsg_send (&msg, handler);
 
-//  Receive response with conditionals (update, last_modified)
+//  4.4 Receive response with conditionals (update, last_modified)
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -369,7 +396,7 @@ xrap_msg_destroy (&xmsg);
 sender = zeb_client_sender (client);
 zuuid_destroy (&sender);
 
-//  Send Request with conditionals (no update)
+//  5.1 Send Request with conditionals (no update)
 xmsg = xrap_msg_new (XRAP_MSG_PUT);
 xrap_msg_set_resource (xmsg, "%s", "/dummy");
 xrap_msg_set_content_type (xmsg, "application/json");
@@ -379,7 +406,7 @@ msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == 0);
 
-//  Check etag (none match)
+//  5.2 Check etag (none match)
 zsock_recv (handler, "ss", &command, &etag);
 assert (streq (command, "CHECK ETAG"));
 zstr_free (&command);
@@ -387,14 +414,14 @@ assert (streq (etag, "NONE MATCH"));
 zstr_free (&etag);
 zsock_signal (handler, 1);
 
-//  Check last modified (modified)
+//  5.3 Check last modified (modified)
 zsock_recv (handler, "s8", &command, &last_modified);
 assert (streq (command, "CHECK LAST MODIFIED"));
 zstr_free (&command);
 assert (last_modified == 20);
 zsock_signal (handler, 1);
 
-//  Receive Request with conditionals (no update)
+//  5.4 Receive Request with conditionals (no update)
 msg = zeb_client_recv (client);
 xmsg = xrap_msg_decode (&msg);
 assert (xrap_msg_id (xmsg) == XRAP_MSG_ERROR);
@@ -406,12 +433,13 @@ zuuid_destroy (&sender);
 //  ================================
 //  Invalid Tests
 
-//  Send Request
+//  1.1 Send Request
 xmsg = xrap_msg_new (XRAP_MSG_GET_EMPTY);
 msg = xrap_msg_encode (&xmsg);
 rc = zeb_client_request (client, 0, &msg);
 assert (rc == XRAP_TRAFFIC_NOT_FOUND);
 
+//  Cleanup
 zeb_client_destroy (&client);
 zactor_destroy (&handler);
 

--- a/include/zeb_handler.h
+++ b/include/zeb_handler.h
@@ -24,7 +24,7 @@ extern "C" {
 #ifdef ZEBRA_BUILD_DRAFT_API
 //  To work with zeb_handler, use the CZMQ zactor API:                      
 //                                                                          
-//  Create new zeb_handler instance, passing broker endpoint:               
+//  Create new zeb_handler instance, passing the broker endpoint:           
 //                                                                          
 //      zactor_t *handler = zactor_new (zeb_handler, "inproc://broker");    
 //                                                                          
@@ -47,8 +47,8 @@ extern "C" {
 //       zsock_signal (handler, 0);                                         
 //    }                                                                     
 //                                                                          
-//    Check if a last modified timestamp is current, MUST signal 0 if true  
-//    otherwise 1.                                                          
+//  Check if a last modified timestamp is current, MUST signal 0 if true    
+//  otherwise 1.                                                            
 //                                                                          
 //    if (streq (command, "CHECK LAST MODIFIED")) {                         
 //       uint64_t last_modified;                                            
@@ -73,8 +73,13 @@ ZEBRA_EXPORT void
 //  *** Draft method, for development use, may change without warning ***
 //  Add a new offer this handler will handle. Returns 0 if successful,
 //  otherwise -1.                                                     
+//  The content type parameter is optional and is used to             
+//  filter requests upon their requested (GET) or provided (POST/PUT) 
+//  content's type. The content type parameter may be a regex. If the 
+//  request's content type does not match it is automatically rejected
+//  with the error code 406 (Not acceptable).                         
 ZEBRA_EXPORT int
-    zeb_handler_add_offer (zactor_t *self, int method, const char *uri);
+    zeb_handler_add_offer (zactor_t *self, int method, const char *uri, const char *content_type);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Add a new accept type that this handler can deliver. May be a regular

--- a/src/xrap_msg.c
+++ b/src/xrap_msg.c
@@ -76,7 +76,7 @@ struct _xrap_msg_t {
 
 //  Put a 1-byte number to the frame
 #define PUT_NUMBER1(host) { \
-    *(byte *) self->needle = (host); \
+    *(byte *) self->needle = (byte) (host); \
     self->needle++; \
 }
 

--- a/src/xrap_traffic.c
+++ b/src/xrap_traffic.c
@@ -69,7 +69,7 @@ struct _xrap_traffic_t {
 
 //  Put a 1-byte number to the frame
 #define PUT_NUMBER1(host) { \
-    *(byte *) self->needle = (host); \
+    *(byte *) self->needle = (byte) (host); \
     self->needle++; \
 }
 

--- a/src/zeb_client_engine.inc
+++ b/src/zeb_client_engine.inc
@@ -1376,7 +1376,7 @@ zeb_client_connected (zeb_client_t *self)
 //  Get valid reply from actor; discard replies that does not match. Current
 //  implementation filters on first frame of message. Blocks until a valid
 //  reply is received, and properties can be loaded from it. Returns 0 if
-//  matched, -1 if interrupted or timed-out.
+//  matched, -1 if interrupted.
 
 static int
 s_accept_reply (zeb_client_t *self, ...)
@@ -1385,7 +1385,7 @@ s_accept_reply (zeb_client_t *self, ...)
     while (!zsys_interrupted) {
         char *reply = zstr_recv (self->actor);
         if (!reply)
-            break;              //  Interrupted or timed-out
+            break;              //  Interrupted
 
         va_list args;
         va_start (args, self);
@@ -1407,12 +1407,12 @@ s_accept_reply (zeb_client_t *self, ...)
         va_end (args);
         //  If anything was remaining on pipe, flush it
         zsock_flush (self->actor);
+        zstr_free (&reply);
         if (filter) {
-            zstr_free (&reply);
             return 0;           //  We matched one of the filters
         }
     }
-    return -1;          //  Interrupted or timed-out
+    return -1;          //  Interrupted
 }
 
 

--- a/src/zeb_handler.c
+++ b/src/zeb_handler.c
@@ -129,6 +129,20 @@ s_handler_destroy (s_handler_t **self_p)
 
 
 //  --------------------------------------------------------------------------
+//  Helper method to destroy the content_type data inserted into the ztrie.
+
+void
+s_destroy_content_type (void **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        zrex_t *self = (zrex_t *) *self_p;
+        zrex_destroy (&self);
+    }
+}
+
+
+//  --------------------------------------------------------------------------
 //  Add a new offer this handler will handle. Returns 0 if successfull,
 //  otherwise 1;
 
@@ -137,17 +151,26 @@ s_handler_add_offer (s_handler_t *self)
 {
     assert (self);
 
+    int rc;
     uint8_t method;
     char *uri = NULL;
-    zsock_brecv (self->pipe, "1s", &method, &uri);
+    char *content_type = NULL;
+    zsock_brecv (self->pipe, "1ss", &method, &uri, &content_type);
     assert (uri);
 
     char *joined_uri = s_concat (method, uri);
-    int rc = ztrie_insert_route (self->offers, joined_uri, NULL, NULL);
+    if (content_type && strlen (content_type)) {
+        zrex_t *content_regex = zrex_new (content_type);
+        rc = ztrie_insert_route (self->offers, joined_uri, content_regex, s_destroy_content_type);
+    }
+    else
+        rc = ztrie_insert_route (self->offers, joined_uri, NULL, NULL);
+
     zstr_free (&joined_uri);
 
     if (rc == 0)
         rc = zeb_client_set_handler (self->client, s_xrap_command (method) + 1, uri);
+
     return rc == -1? 1: rc;
 }
 
@@ -178,6 +201,66 @@ s_handler_add_accept (s_handler_t *self)
 
 
 //  --------------------------------------------------------------------------
+//
+
+char *
+s_strndup (const char *s, size_t size) {
+    char *dup;
+    char *end = (char *) memchr (s, '\0', size);
+    if (end)
+        size = end - 1 - s;     //  -1 to get the last char before '\0'
+
+    dup = (char *) zmalloc (sizeof (char) * size + 1); //  +1 for trailing '\0'
+    if (size) {
+        memcpy (dup, s, size);
+        dup [size] = '\0';
+    }
+    return dup;
+}
+
+
+//  --------------------------------------------------------------------------
+//
+
+static bool
+s_handler_check_content_type (zrex_t *valid_type, const char *content_type)
+{
+    assert (valid_type);
+    assert (content_type);
+
+    char *start =  (char *) content_type;
+    char *end = start + strlen (content_type);
+    char *pos;
+    while (start < end) {
+        //  Ignore any spaces
+        while (start < end && *start == ' ')
+            start++;
+
+        //  Read accept type
+        pos = start;
+        while (pos < end && *pos != ',' && *pos != ';')
+            pos++;
+
+        //  Check if type matches
+        char *type = s_strndup (start, pos - start);
+        if (zrex_matches (valid_type, type))
+            return true;
+
+        //  Discard quality and level attributes
+        if (*pos == ';')
+            while (pos < end && *pos != ',')
+                pos++;
+
+        if (*pos == ',')
+            pos++;
+
+        start = pos;
+    }
+    return false;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Deliver an XRAP response back to the caller.
 
 static void
@@ -201,22 +284,23 @@ s_handler_recv_client (s_handler_t *self)
 
     {   // Jump scoping needed for c++
         //  Check if content type is valid
-        bool matching_accept = false;
-        const char *content_type = xrap_msg_content_type (xrequest);
-        zrex_t *accept_expr = (zrex_t *) zlistx_first (self->accepts);
-        while (accept_expr) {
-            if (zrex_matches (accept_expr, content_type))
-                matching_accept = true;
-            accept_expr = (zrex_t *) zlistx_next (self->accepts);
+        char *joined_uri = s_concat (xrap_id, xrap_msg_resource (xrequest));
+        (void) ztrie_matches (self->offers, joined_uri);
+        zrex_t *content_regex = (zrex_t *) ztrie_hit_data (self->offers);
+        //  Proceed if a regex has been provided
+        if (content_regex) {
+            const char *content_type = xrap_msg_content_type (xrequest);
+            if (!content_type || !strlen (content_type) ||
+                !s_handler_check_content_type (content_regex, content_type)) {
+                xrap_msg_t *xresponse = xrap_msg_new (XRAP_MSG_ERROR);
+                xrap_msg_set_status_code (xresponse, XRAP_TRAFFIC_NOT_ACCEPTABLE);
+                xrap_msg_set_status_text (xresponse, "Ressource accept format is not valid!");
+                zmsg_t *response = xrap_msg_encode (&xresponse);
+                zeb_client_deliver (self->client, zeb_client_sender (self->client), &response);
+                goto cleanup;
+            }
         }
-        if (!matching_accept) {
-            xrap_msg_t *xresponse = xrap_msg_new (XRAP_MSG_ERROR);
-            xrap_msg_set_status_code (xresponse, XRAP_TRAFFIC_NOT_ACCEPTABLE);
-            xrap_msg_set_status_text (xresponse, "Ressource accept format is not valid!");
-            zmsg_t *response = xrap_msg_encode (&xresponse);
-            zeb_client_deliver (self->client, zeb_client_sender (self->client), &response);
-            goto cleanup;
-        }
+        free (joined_uri);
     }
 
     {   // Jump scoping needed for c++
@@ -376,7 +460,7 @@ zeb_handler_add_accept (zactor_t *self, const char *accept)
 //  otherwise -1;
 
 int
-zeb_handler_add_offer (zactor_t *self, int method, const char *uri)
+zeb_handler_add_offer (zactor_t *self, int method, const char *uri, const char *content_type)
 {
     assert (self);
     assert (uri);
@@ -384,7 +468,7 @@ zeb_handler_add_offer (zactor_t *self, int method, const char *uri)
     //  Send message name as first, separate frame
     rc = zstr_sendm (self, "ADD OFFER");
     if (rc == 0)
-        rc = zsock_bsend (self, "1s", (uint8_t) method, uri);
+        rc = zsock_bsend (self, "1ss", (uint8_t) method, uri, content_type);
     if (rc == 0)
         rc = zsock_wait (self);
     return rc == 1? -1: rc;
@@ -418,24 +502,20 @@ zeb_handler_test (bool verbose)
     zactor_t *handler = zactor_new (zeb_handler, (void *) "tcp://127.0.0.1:9999");
     assert (handler);
 
-    //  Set accepted document formats
-    rc = zeb_handler_add_accept (handler, "application/(xml|json)");
-    assert (rc == 0);
-
     //  Offer a service
-    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy");
+    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy", "application/(xml|json)");
     assert (rc == 0);
-    rc = zeb_handler_add_offer (handler, XRAP_MSG_PUT, "/dummy");
+    rc = zeb_handler_add_offer (handler, XRAP_MSG_PUT, "/dummy", "application/(xml|json)");
     assert (rc == 0);
 
     //  Provide Rubbish Offering
-    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy");
+    rc = zeb_handler_add_offer (handler, XRAP_MSG_GET, "/dummy", NULL);
     assert (rc == -1);
 
     //  ================================
     //  GET Tests
 
-    //  Send Request
+    //  1.1 Send Request
     xrap_msg_t *xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/xml");
@@ -443,14 +523,14 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Receive request and Echo response
+    //  1.2 Receive request and Echo response
     char *command;
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
 
-    //  Receive Response (is echo)
+    //  1.3 Receive Response (is echo)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
@@ -460,14 +540,40 @@ zeb_handler_test (bool verbose)
     zuuid_t *sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request without ACCEPT
+    //  2.1 Send Request with default Firefox accept header
+    xmsg = xrap_msg_new (XRAP_MSG_GET);
+    xrap_msg_set_resource (xmsg, "%s", "/dummy");
+    xrap_msg_set_content_type (xmsg,
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+    msg = xrap_msg_encode (&xmsg);
+    rc = zeb_client_request (client, 0, &msg);
+    assert (rc == 0);
+
+    //  2.2 Receive request and Echo response
+    zsock_recv (handler, "sm", &command, &msg);
+    assert (streq (command, "HANDLE REQUEST"));
+    zstr_free (&command);
+    zmsg_send (&msg, handler);
+
+    //  2.3 Receive Response (is echo)
+    msg = zeb_client_recv (client);
+    xmsg = xrap_msg_decode (&msg);
+    assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
+    assert (streq (xrap_msg_resource (xmsg), "/dummy"));
+    assert (streq (xrap_msg_content_type (xmsg),
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"));
+    xrap_msg_destroy (&xmsg);
+    sender = zeb_client_sender (client);
+    zuuid_destroy (&sender);
+
+    //  3.1 Send Request without ACCEPT
     xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     msg = xrap_msg_encode (&xmsg);
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Receive Request without ACCEPT
+    //  3.2 Receive Request without ACCEPT
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_ERROR);
@@ -476,7 +582,7 @@ zeb_handler_test (bool verbose)
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request with conditionals (not changed)
+    //  4.1 Send Request with conditionals (not changed)
     xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -486,7 +592,7 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Check etag (match)
+    //  4.2 Check etag (match)
     char *etag;
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
@@ -495,14 +601,14 @@ zeb_handler_test (bool verbose)
     zstr_free (&etag);
     zsock_signal (handler, 0);
 
-    //  Check last modified (not modified)
+    //  4.3 Check last modified (not modified)
     uint64_t last_modified;
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     zsock_signal (handler, 0);
 
-    //  Receive Request with conditionals
+    //  4.4 Receive Request with conditionals
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_GET_EMPTY);
@@ -510,7 +616,7 @@ zeb_handler_test (bool verbose)
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request with conditionals (changed)
+    //  5.1 Send Request with conditionals (changed)
     xmsg = xrap_msg_new (XRAP_MSG_GET);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -520,7 +626,7 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Check etag (none match)
+    //  5.2 Check etag (none match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -528,20 +634,20 @@ zeb_handler_test (bool verbose)
     zstr_free (&etag);
     zsock_signal (handler, 1);
 
-    //  Check last modified (modified)
+    //  5.3 Check last modified (modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     assert (last_modified == 20);
     zsock_signal (handler, 1);
 
-    //  Receive request and Echo response
+    //  5.4 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
 
-    //  Receive response with conditionals
+    //  5.5 Receive response with conditionals
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_GET);
@@ -554,7 +660,7 @@ zeb_handler_test (bool verbose)
     //  ================================
     //  PUT Tests
 
-    //  Send Request
+    //  1.1 Send Request
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/xml");
@@ -563,13 +669,13 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Receive request and Echo response
+    //  1.2 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
 
-    //  Receive response (is echo)
+    //  1.3 Receive response (is echo)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -580,7 +686,7 @@ zeb_handler_test (bool verbose)
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request with conditionals (update, both)
+    //  2.1 Send Request with conditionals (update, both)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -590,7 +696,7 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Check etag (match)
+    //  2.2 Check etag (match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -598,19 +704,19 @@ zeb_handler_test (bool verbose)
     zstr_free (&etag);
     zsock_signal (handler, 0);
 
-    //  Check last modified (not modified)
+    //  2.3 Check last modified (not modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     zsock_signal (handler, 0);
 
-    //  Receive request and Echo response
+    //  2.4 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
 
-    //  Receive response with conditionals (update, both)
+    //  2.5 Receive response with conditionals (update, both)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -620,7 +726,7 @@ zeb_handler_test (bool verbose)
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request with conditionals (update, etag)
+    //  3.1 Send Request with conditionals (update, etag)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -629,7 +735,7 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Check etag (match)
+    //  3.2 Check etag (match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -637,13 +743,13 @@ zeb_handler_test (bool verbose)
     zstr_free (&etag);
     zsock_signal (handler, 0);
 
-    //  Receive request and Echo response
+    //  3.3 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
 
-    //  Receive response with conditionals (update, etag)
+    //  3.4 Receive response with conditionals (update, etag)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -651,7 +757,7 @@ zeb_handler_test (bool verbose)
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request with conditionals (update, last_modified)
+    //  4.1 Send Request with conditionals (update, last_modified)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -660,19 +766,19 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Check last modified (not modified)
+    //  4.2 Check last modified (not modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     zsock_signal (handler, 0);
 
-    //  Receive request and Echo response
+    //  4.3 Receive request and Echo response
     zsock_recv (handler, "sm", &command, &msg);
     assert (streq (command, "HANDLE REQUEST"));
     zstr_free (&command);
     zmsg_send (&msg, handler);
 
-    //  Receive response with conditionals (update, last_modified)
+    //  4.4 Receive response with conditionals (update, last_modified)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_PUT);
@@ -680,7 +786,7 @@ zeb_handler_test (bool verbose)
     sender = zeb_client_sender (client);
     zuuid_destroy (&sender);
 
-    //  Send Request with conditionals (no update)
+    //  5.1 Send Request with conditionals (no update)
     xmsg = xrap_msg_new (XRAP_MSG_PUT);
     xrap_msg_set_resource (xmsg, "%s", "/dummy");
     xrap_msg_set_content_type (xmsg, "application/json");
@@ -690,7 +796,7 @@ zeb_handler_test (bool verbose)
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == 0);
 
-    //  Check etag (none match)
+    //  5.2 Check etag (none match)
     zsock_recv (handler, "ss", &command, &etag);
     assert (streq (command, "CHECK ETAG"));
     zstr_free (&command);
@@ -698,14 +804,14 @@ zeb_handler_test (bool verbose)
     zstr_free (&etag);
     zsock_signal (handler, 1);
 
-    //  Check last modified (modified)
+    //  5.3 Check last modified (modified)
     zsock_recv (handler, "s8", &command, &last_modified);
     assert (streq (command, "CHECK LAST MODIFIED"));
     zstr_free (&command);
     assert (last_modified == 20);
     zsock_signal (handler, 1);
 
-    //  Receive Request with conditionals (no update)
+    //  5.4 Receive Request with conditionals (no update)
     msg = zeb_client_recv (client);
     xmsg = xrap_msg_decode (&msg);
     assert (xrap_msg_id (xmsg) == XRAP_MSG_ERROR);
@@ -717,12 +823,13 @@ zeb_handler_test (bool verbose)
     //  ================================
     //  Invalid Tests
 
-    //  Send Request
+    //  1.1 Send Request
     xmsg = xrap_msg_new (XRAP_MSG_GET_EMPTY);
     msg = xrap_msg_encode (&xmsg);
     rc = zeb_client_request (client, 0, &msg);
     assert (rc == XRAP_TRAFFIC_NOT_FOUND);
 
+    //  Cleanup
     zeb_client_destroy (&client);
     zactor_destroy (&handler);
 


### PR DESCRIPTION
Solution: make zeb_handler parse the accept header and extract accept
types and compare them against the matched resource valid content type
regex.
