### PR TITLE
Fixes for HTTP POST/PUT processing and testing

### DIFF
--- a/src/zeb_curl_client.c
+++ b/src/zeb_curl_client.c
@@ -66,8 +66,8 @@ zeb_curl_client_destroy (zeb_curl_client_t **self_p)
         curl_multi_cleanup (self->multi_handle);
 
         //  Free object itself
-        free (self);
         zstr_free (&self->data);
+        free (self);
         *self_p = NULL;
     }
 }

--- a/src/zeb_microhttpd.c
+++ b/src/zeb_microhttpd.c
@@ -425,8 +425,9 @@ answer_to_connection (void *cls,
     else {
         connection = (zeb_connection_t *) *con_cls;
     }
-    //  DEBUG: debug print of http request
-    /*zeb_request_print (zeb_connection_request (connection));*/
+
+    if (self->verbose)
+        zeb_request_print (zeb_connection_request (connection));
 
     //  Start request processing
     if ((0 == strcmp (method, MHD_HTTP_METHOD_POST) ||
@@ -819,6 +820,8 @@ zeb_microhttpd_test (bool verbose)
     assert (request);
     xrap_msg = xrap_msg_decode (&request);
     assert (xrap_msg_id (xrap_msg) == XRAP_MSG_POST);
+    assert (streq (xrap_msg_content_type (xrap_msg), "text/plain"));
+    assert (streq (xrap_msg_content_body (xrap_msg), "abc"));
     assert (streq ("/foo/bar", xrap_msg_parent (xrap_msg)));
     xrap_msg_destroy (&xrap_msg);
 
@@ -836,7 +839,7 @@ zeb_microhttpd_test (bool verbose)
     zuuid_destroy (&sender);
 
     //  Give response time to arrive
-    usleep (250);
+    zclock_sleep (250);
 
     zeb_curl_client_verify_response (curl, 201, "Hello World!");
     zeb_curl_client_destroy (&curl);

--- a/src/zeb_request.c
+++ b/src/zeb_request.c
@@ -26,7 +26,7 @@ struct _zeb_request_t {
     const char *path;
     const char *action;
     const char *version;
-    const char *data;
+    char *data;
     size_t data_size;
     zhash_t *header;
     zhash_t *query;
@@ -69,6 +69,7 @@ zeb_request_destroy (zeb_request_t **self_p)
         zeb_request_t *self = *self_p;
 
         //  Free class properties
+        zstr_free (&self->data);
         zhash_destroy (&self->header);
         zhash_destroy (&self->query);
 
@@ -132,7 +133,7 @@ zeb_request_data (zeb_request_t *self)
 //  Set request data from POST or PUT
 
 void
-zeb_request_set_data (zeb_request_t *self, const char *data, size_t data_size)
+zeb_request_set_data (zeb_request_t *self, char *data, size_t data_size)
 {
     assert (self);
     self->data = data;

--- a/src/zeb_request.h
+++ b/src/zeb_request.h
@@ -53,7 +53,7 @@ ZEBRA_EXPORT const char *
 
 //  Set request data from POST or PUT
 ZEBRA_EXPORT void
-    zeb_request_set_data (zeb_request_t *self, const char *data, size_t data_size);
+    zeb_request_set_data (zeb_request_t *self, char *data, size_t data_size);
 
 //  Get the request's data size, if data NULL then returns 0
 ZEBRA_EXPORT size_t


### PR DESCRIPTION
- Problem: zeb_curl struct is free'd before data is free'd
- Problem: POST/PUT data can be split across many frames
- Problem: Test code not checking POST data
